### PR TITLE
Harden message parsing on error

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -32,7 +32,7 @@ var parseMessage = function(res, body) {
   // }
 
   var messages = [];
-  if (body.messages instanceof Array && body.messages.length > 0) {
+  if (body && body.messages && body.messages instanceof Array && body.messages.length > 0) {
     // parse messages array from body
     body.messages.forEach(function (message) {
       messages.push(message.text);


### PR DESCRIPTION
Discovered this in testing the no-@-in-username issue , if the response isn't JSON this will be undefined so best cater for it